### PR TITLE
fix: remove type from uiEvent

### DIFF
--- a/docs/notify.md
+++ b/docs/notify.md
@@ -24,7 +24,7 @@ import { uiEventSubject } from '@linagora/linid-im-front-corelib';
 // Subscribe to all notification events
 uiEventSubject.subscribe((event) => {
   if (event.key === 'notify') {
-    console.log('Notification:', event.type, event.data);
+    console.log('Notification:', event.data);
   }
 });
 ```
@@ -39,7 +39,6 @@ Each notification event follows the `UiEvent` interface:
 ```ts
 interface UiEvent {
   key: string;
-  type: string;
   data: QNotifyCreateOptions;
 }
 ```

--- a/src/composables/useNotify.ts
+++ b/src/composables/useNotify.ts
@@ -40,7 +40,6 @@ export function useNotify() {
   function Notify(data: QNotifyCreateOptions): void {
     uiEventSubject.next({
       key: 'notify',
-      type: 'open',
       data,
     });
   }

--- a/src/types/uiEvent.ts
+++ b/src/types/uiEvent.ts
@@ -33,10 +33,6 @@ export interface UiEvent {
    */
   key: string;
   /**
-   * Event type.
-   */
-  type: string;
-  /**
    * Event data.
    */
   data: unknown;

--- a/tests/unit/composables/useNotify.spec.js
+++ b/tests/unit/composables/useNotify.spec.js
@@ -29,7 +29,6 @@ describe('Test composable: useNotify', () => {
     expect(events.length).toBe(1);
     expect(events[0]).toEqual({
       key: 'notify',
-      type: 'open',
       data: payload,
     });
   });


### PR DESCRIPTION
Finally we don't need type in uiEvent because we can put it in data. https://github.com/linagora/linid-im-front/pull/45#discussion_r2698396004