### PR TITLE
feat(core): add i18n locale management to UI store and scoped i18n

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -138,7 +138,50 @@ const message = translateOrDefault('Hello!', 'greeting', { username: 'Alice' });
 
 ---
 
-## 4. Full Example in a Vue 3 + Quasar Component
+## 4. Locale Management
+
+Three helpers manage the active locale, its resolution, and its persistence. They rely on the shared i18n singleton
+and on the UI store (`useLinidUiStore`), which must hold the available languages and current locale. The host is
+responsible for populating the store during boot (via `setAvailableLanguages` and `setLocale`) **before** these
+helpers are called, since `resolveLocale` reads the supported languages from the store.
+
+### 4.1 `resolveLocale`
+
+Resolves the effective locale to apply, without any side effect. Resolution priority: stored user preference, then
+locally persisted language (`localStorage`), falling back to the locale held in the UI store when none is supported.
+
+```ts
+import { resolveLocale } from '@linagora/linid-im-front-corelib';
+
+const locale = resolveLocale();
+```
+
+### 4.2 `syncLocale`
+
+Synchronises the persisted state with the given locale. The locale is always written to `localStorage`. The
+server-side user preference is updated only when it differs from the currently stored one.
+
+```ts
+import { syncLocale } from '@linagora/linid-im-front-corelib';
+
+await syncLocale('fr-FR');
+```
+
+### 4.3 `changeLocale`
+
+Applies the given locale to the application and persists the choice: updates the active i18n locale, reflects it in
+the UI store (`setLocale`), and synchronises the persisted state via `syncLocale`. This is the function to call from
+a language switcher.
+
+```ts
+import { changeLocale } from '@linagora/linid-im-front-corelib';
+
+await changeLocale('fr-FR');
+```
+
+---
+
+## 5. Full Example in a Vue 3 + Quasar Component
 
 ```vue
 
@@ -162,7 +205,7 @@ const message = translateOrDefault('Hello!', 'greeting', { username: 'Alice' });
 
 ---
 
-## 5. Best Practices
+## 6. Best Practices
 
 * Always call `setI18nInstance()` **once** during app boot.
 * Use descriptive namespaces for different modules or features.
@@ -171,7 +214,7 @@ const message = translateOrDefault('Hello!', 'greeting', { username: 'Alice' });
 
 ---
 
-## 6. TypeScript Support
+## 7. TypeScript Support
 
 The composable preserves type safety with Vue I18n's `ComposerTranslation` type:
 

--- a/docs/types-and-interfaces.md
+++ b/docs/types-and-interfaces.md
@@ -1272,6 +1272,13 @@ Represents the state of the Pinia store that manages UI-related configurations.
 interface LinidUiState {
   /** List of main navigation menu items. */
   mainNavigationItems: NavigationMenuItem[];
+  /** Internationalization state: active locale and available languages. */
+  i18n: {
+    /** Currently active locale code (e.g. "fr-FR"). */
+    locale: string;
+    /** List of available locale codes declared in the configuration. */
+    languages: string[];
+  };
 }
 ```
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -152,6 +152,11 @@ export default defineConfigWithVueTs(
       '**/__tests__/**',
       '**/*.config.*',
     ],
+    languageOptions: {
+      globals: {
+        localStorage: 'readonly',
+      },
+    },
     rules: {
       'jsdoc/require-jsdoc': 'off',
       'headers/header-format': 'off',

--- a/src/composables/useScopedI18n.ts
+++ b/src/composables/useScopedI18n.ts
@@ -24,8 +24,11 @@
  * LinID Identity Manager software.
  */
 
+import type { WritableComputedRef } from 'vue';
 import { type ComposerTranslation, useI18n } from 'vue-i18n';
 import { getI18nInstance } from '../services/i18nService';
+import { useLinidUiStore } from '../stores/linidUiStore';
+import { useLinidUserPreference } from './useLinidUserPreference';
 
 /**
  * Creates a scoped i18n translator bound to a specific translation namespace.
@@ -157,4 +160,74 @@ export function useScopedI18n(scope: string): {
     tm: _tm as ComposerTranslation,
     translateOrDefault,
   };
+}
+
+const LOCALE_STORAGE_KEY = 'language';
+
+/**
+ * Tells whether a language candidate is defined and part of the supported languages.
+ * @param lang - The language candidate to check.
+ * @returns `true` when the candidate is a non-empty, supported language.
+ */
+function isSupportedLanguage(lang?: string | null): lang is string {
+  const uiStore = useLinidUiStore();
+  return !!lang && uiStore.i18n.languages.includes(lang);
+}
+
+/**
+ * Resolves the effective locale to apply, without any side effect.
+ *
+ * The locale is resolved by priority: the stored user preference first, then the locally persisted language.
+ * If neither the stored preference nor the localStorage value is a supported language, the UI store locale is used as the fallback.
+ * @returns The locale code the caller should apply to its i18n target.
+ */
+export function resolveLocale(): string {
+  const { userPreferenceStore } = useLinidUserPreference();
+  const uiStore = useLinidUiStore();
+  const storedPreference =
+    userPreferenceStore.userPreferences?.[LOCALE_STORAGE_KEY];
+
+  return (
+    [storedPreference, localStorage.getItem(LOCALE_STORAGE_KEY)].find(
+      isSupportedLanguage
+    ) ?? uiStore.i18n.locale
+  );
+}
+
+/**
+ * Synchronises the persisted state with the given locale.
+ *
+ * The locale is always written to localStorage. The server-side user preference is updated only when it differs from
+ * the currently stored one.
+ * @param locale - The locale to persist.
+ * @returns A promise that resolves once the persisted state has been synchronised.
+ */
+export async function syncLocale(locale: string): Promise<void> {
+  const { userPreferenceStore, saveUserPreference } = useLinidUserPreference();
+  const storedPreference =
+    userPreferenceStore.userPreferences?.[LOCALE_STORAGE_KEY];
+
+  localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+
+  if (locale !== storedPreference) {
+    await saveUserPreference(LOCALE_STORAGE_KEY, locale);
+  }
+}
+
+/**
+ * Applies the given locale to the application and persists the choice.
+ *
+ * Updates the active i18n locale, reflects it in the UI store, and synchronises the persisted state. This assumes the
+ * shared i18n instance runs in Composition mode (legacy: false), as guaranteed by the corelib LinidI18n convention;
+ * on a legacy instance the locale assignment would be a silent no-op at runtime.
+ * @param locale - The locale code to apply (e.g. "fr-FR").
+ * @returns A promise that resolves once the locale has been applied and persisted.
+ */
+export async function changeLocale(locale: string): Promise<void> {
+  const uiStore = useLinidUiStore();
+  const i18n = getI18nInstance();
+
+  (i18n.global.locale as WritableComputedRef<string>).value = locale;
+  uiStore.setLocale(locale);
+  await syncLocale(locale);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,12 @@ export { usePagination } from './composables/usePagination';
 export { QDATE_DEFAULT_MASK, useQuasarDate } from './composables/useQuasarDate';
 export { useQuasarFieldValidation } from './composables/useQuasarFieldValidation';
 export { useQuasarRules } from './composables/useQuasarRules';
-export { useScopedI18n } from './composables/useScopedI18n';
+export {
+  changeLocale,
+  resolveLocale,
+  syncLocale,
+  useScopedI18n,
+} from './composables/useScopedI18n';
 export { useTree } from './composables/useTree';
 export { useUiDesign } from './composables/useUiDesign';
 export { useLinidFilterUrl } from './composables/useLinidFilterUrl';

--- a/src/stores/linidUiStore.ts
+++ b/src/stores/linidUiStore.ts
@@ -34,6 +34,13 @@ import type { NavigationMenuItem } from '../types/linidUi';
 interface LinidUiState {
   /** List of main navigation menu items. */
   mainNavigationItems: NavigationMenuItem[];
+  /** Internationalization state: active locale and available languages. */
+  i18n: {
+    /** Currently active locale code (e.g. "fr-FR"). */
+    locale: string;
+    /** List of available locale codes declared in the configuration. */
+    languages: string[];
+  };
 }
 
 /**
@@ -50,6 +57,10 @@ export const useLinidUiStore = () => _useLinidUiStore(getPiniaStore());
 const _useLinidUiStore = defineStore('LinidUiStore', {
   state: (): LinidUiState => ({
     mainNavigationItems: [],
+    i18n: {
+      locale: '',
+      languages: [],
+    },
   }),
 
   actions: {
@@ -59,6 +70,22 @@ const _useLinidUiStore = defineStore('LinidUiStore', {
      */
     addMainNavigationMenuItems(...items: NavigationMenuItem[]): void {
       this.mainNavigationItems.push(...items);
+    },
+
+    /**
+     * Sets the list of available locale codes.
+     * @param languages - The available locale codes (e.g. ["fr-FR", "en-US"]).
+     */
+    setAvailableLanguages(languages: string[]): void {
+      this.i18n.languages = languages;
+    },
+
+    /**
+     * Sets the active locale code.
+     * @param locale - The locale code to activate (e.g. "fr-FR").
+     */
+    setLocale(locale: string): void {
+      this.i18n.locale = locale;
     },
   },
 });

--- a/tests/unit/composables/useScopedI18n.spec.js
+++ b/tests/unit/composables/useScopedI18n.spec.js
@@ -1,13 +1,29 @@
-import { useScopedI18n } from 'src/composables/useScopedI18n.ts';
+import { useLinidUserPreference } from 'src/composables/useLinidUserPreference.ts';
+import {
+  changeLocale,
+  resolveLocale,
+  syncLocale,
+  useScopedI18n,
+} from 'src/composables/useScopedI18n.ts';
 import { getI18nInstance, setI18nInstance } from 'src/services/i18nService.ts';
-import { describe, expect, it, vi } from 'vitest';
+import { useLinidUiStore } from 'src/stores/linidUiStore.ts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => getI18nInstance(),
 }));
 
+vi.mock('src/stores/linidUiStore.ts', () => ({
+  useLinidUiStore: vi.fn(),
+}));
+
+vi.mock('src/composables/useLinidUserPreference.ts', () => ({
+  useLinidUserPreference: vi.fn(),
+}));
+
 describe('Test composable: useScopedI18n', () => {
   setI18nInstance({
+    global: { locale: { value: 'fr-FR' } },
     t: (a, b, c) => `${a} ${b} ${c}`,
     te: (key) => key !== 'test.missing',
     tm: (key) => (key === 'test.exists' ? 'raw message' : undefined),
@@ -64,6 +80,96 @@ describe('Test composable: useScopedI18n', () => {
       const { translateOrDefault } = useScopedI18n('test');
 
       expect(translateOrDefault('fallback', 'missing', 1)).toEqual('fallback');
+    });
+  });
+
+  describe('Test function: resolveLocale', () => {
+    beforeEach(() => {
+      vi.mocked(useLinidUiStore).mockReturnValue({
+        i18n: { locale: 'fr-FR', languages: ['fr-FR', 'en-US'] },
+      });
+      localStorage.clear();
+    });
+
+    it('should return the user preference when supported', () => {
+      vi.mocked(useLinidUserPreference).mockReturnValue({
+        userPreferenceStore: { userPreferences: { language: 'en-US' } },
+      });
+
+      expect(resolveLocale()).toBe('en-US');
+    });
+
+    it('should fall back to localStorage when no preference', () => {
+      vi.mocked(useLinidUserPreference).mockReturnValue({
+        userPreferenceStore: { userPreferences: {} },
+      });
+      localStorage.setItem('language', 'en-US');
+
+      expect(resolveLocale()).toBe('en-US');
+    });
+
+    it('should fall back to the store locale when nothing is supported', () => {
+      vi.mocked(useLinidUserPreference).mockReturnValue({
+        userPreferenceStore: { userPreferences: {} },
+      });
+
+      expect(resolveLocale()).toBe('fr-FR');
+    });
+  });
+
+  describe('Test function: syncLocale', () => {
+    let saveUserPreference;
+
+    beforeEach(() => {
+      saveUserPreference = vi.fn();
+      localStorage.clear();
+    });
+
+    it('should persist the preference when it differs', async () => {
+      vi.mocked(useLinidUserPreference).mockReturnValue({
+        userPreferenceStore: { userPreferences: { language: 'fr-FR' } },
+        saveUserPreference,
+      });
+
+      await syncLocale('en-US');
+
+      expect(localStorage.getItem('language')).toBe('en-US');
+      expect(saveUserPreference).toHaveBeenCalledWith('language', 'en-US');
+    });
+
+    it('should write localStorage without saving when value equals stored preference (boot path)', async () => {
+      vi.mocked(useLinidUserPreference).mockReturnValue({
+        userPreferenceStore: { userPreferences: { language: 'en-US' } },
+        saveUserPreference,
+      });
+
+      await syncLocale('en-US');
+
+      expect(localStorage.getItem('language')).toBe('en-US');
+      expect(saveUserPreference).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Test function: changeLocale', () => {
+    it('should apply the locale to the store and persist it', async () => {
+      const setLocale = vi.fn();
+      const saveUserPreference = vi.fn();
+
+      vi.mocked(useLinidUiStore).mockReturnValue({
+        i18n: { locale: 'fr-FR', languages: ['fr-FR', 'en-US'] },
+        setLocale,
+      });
+      vi.mocked(useLinidUserPreference).mockReturnValue({
+        userPreferenceStore: { userPreferences: { language: 'fr-FR' } },
+        saveUserPreference,
+      });
+      const i18n = getI18nInstance();
+
+      await changeLocale('en-US');
+
+      expect(i18n.global.locale.value).toBe('en-US');
+      expect(setLocale).toHaveBeenCalledWith('en-US');
+      expect(saveUserPreference).toHaveBeenCalledWith('language', 'en-US');
     });
   });
 });

--- a/tests/unit/stores/linidUiStore.spec.js
+++ b/tests/unit/stores/linidUiStore.spec.js
@@ -23,6 +23,7 @@ describe('Test store: linidUiStore', () => {
   describe('Test initial state', () => {
     it('should have empty initial state', () => {
       expect(store.mainNavigationItems).toEqual([]);
+      expect(store.i18n).toEqual({ locale: '', languages: [] });
     });
   });
 
@@ -34,6 +35,21 @@ describe('Test store: linidUiStore', () => {
       ];
       store.addMainNavigationMenuItems(...items);
       expect(store.mainNavigationItems).toEqual(items);
+    });
+  });
+
+  describe('Test action: setLocale', () => {
+    it('should set the active locale', () => {
+      store.setLocale('fr-FR');
+      expect(store.i18n.locale).toBe('fr-FR');
+    });
+  });
+
+  describe('Test action: setAvailableLanguages', () => {
+    it('should set the available languages', () => {
+      const languages = ['fr-FR', 'en-US'];
+      store.setAvailableLanguages(languages);
+      expect(store.i18n.languages).toEqual(languages);
     });
   });
 });


### PR DESCRIPTION
## Moves i18n locale management into the corelib so it can be used by the host and the plugins without depending on host-specific code.

* adds `i18n` state (`locale`, `languages`) and `setLocale` / `setAvailableLanguages` actions to `useLinidUiStore`
* moves `resolveLocale` / `syncLocale` logic into `useScopedI18n`, reading the store instead of `appConfig`
* adds `changeLocale` to apply the locale to vue-i18n, reflect it in the store, and persist it
* exports the new functions
* updates docs (`i18n.md`, `types-and-interfaces.md`)

The store is filled by the host at boot (the corelib never reads `appConfig`). The auth check is handled by the caller.